### PR TITLE
Implement basic support for the content-security-policy header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ name = "pheasant"
 version = "0.1.0"
 edition = "2024"
 
-[[example]]
-path = "examples/basic"
-name = "basic"
+# [[example]]
+# path = "examples/basic"
+# name = "basic"
 
 [workspace]
 members = [

--- a/crates/pheasant_services/Cargo.toml
+++ b/crates/pheasant_services/Cargo.toml
@@ -3,13 +3,13 @@ name = "pheasant_services"
 version = "0.1.0"
 edition = "2024"
 
-[[example]]
-name = "sha"
-path = "examples/pswd.rs"
+# [[example]]
+# name = "sha"
+# path = "examples/pswd.rs"
 
 [[test]]
 name = "net_reset"
-path = "tests/connection_reset"
+path = "tests/connection_reset.rs"
 
 [dependencies]
 # bb8 = "0.9.0"

--- a/crates/pheasant_services/src/content_security_policy.rs
+++ b/crates/pheasant_services/src/content_security_policy.rs
@@ -19,11 +19,12 @@ impl<'a> ContentSecurityPolicy<'a> {
     }
 
     pub fn write_header(&self, buf: &mut Vec<u8>) {
-        buf.extend(b"content-security-policy");
+        buf.extend(b"content-security-policy:");
         for policy in self.policies.iter() {
             buf.extend(policy.stream_bytes());
             buf.push(b';');
         }
+        buf.push(10);
     }
 }
 
@@ -48,10 +49,10 @@ impl FetchDirective {
 
     pub fn as_bytes(&self) -> &'static [u8] {
         match self {
-            Self::Default => b"default-src",
-            Self::Image => b"img-src",
-            Self::Script => b"script-src",
-            Self::Style => b"style-src",
+            Self::Default => b" default-src",
+            Self::Image => b" img-src",
+            Self::Script => b" script-src",
+            Self::Style => b" style-src",
         }
     }
 }

--- a/crates/pheasant_services/src/content_security_policy.rs
+++ b/crates/pheasant_services/src/content_security_policy.rs
@@ -1,0 +1,151 @@
+use hashbrown::HashSet;
+
+#[derive(Debug, Default, Clone)]
+pub struct ContentSecurityPolicy<'a> {
+    policies: HashSet<ContentSecurity<'a>>,
+}
+
+impl<'a> ContentSecurityPolicy<'a> {
+    pub fn policy(mut self, policy: ContentSecurity<'a>) -> Self {
+        self.policies.insert(policy);
+
+        self
+    }
+
+    pub fn policies(mut self, policies: impl IntoIterator<Item = ContentSecurity<'a>>) -> Self {
+        self.policies.extend(policies);
+
+        self
+    }
+
+    pub fn write_header(&self, buf: &mut Vec<u8>) {
+        buf.extend(b"content-security-policy");
+        for policy in self.policies.iter() {
+            buf.extend(policy.stream_bytes());
+            buf.push(b';');
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FetchDirective {
+    #[default]
+    Default = 0,
+    Image = 1,
+    Script = 2,
+    Style = 4,
+}
+
+impl FetchDirective {
+    // pub fn as_u8(&self) -> u8 {
+    //     match self {
+    //         Self::Default => 0,
+    //         Self::Image => 1,
+    //         Self::Script => 2,
+    //         Self::Style => 4,
+    //     }
+    // }
+
+    pub fn as_bytes(&self) -> &'static [u8] {
+        match self {
+            Self::Default => b"default-src",
+            Self::Image => b"img-src",
+            Self::Script => b"script-src",
+            Self::Style => b"style-src",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentSecurity<'a> {
+    directive: FetchDirective,
+    origins: HashSet<&'a str>,
+    same_origin: bool,
+}
+
+impl<'a> core::hash::Hash for ContentSecurity<'a> {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: core::hash::Hasher,
+    {
+        self.directive.hash(state);
+    }
+}
+
+impl<'a> Default for ContentSecurity<'a> {
+    fn default() -> Self {
+        Self {
+            directive: FetchDirective::default(),
+            origins: HashSet::new(),
+            same_origin: true,
+        }
+    }
+}
+
+impl<'a> ContentSecurity<'a> {
+    /// makes a new instance with the provided fetch directive
+    pub fn new(directive: FetchDirective) -> Self {
+        Self {
+            directive,
+            origins: HashSet::new(),
+            same_origin: true,
+        }
+    }
+
+    /// disables the self source expression, which is enabled by default
+    pub fn no_self(mut self) -> Self {
+        self.same_origin = false;
+
+        self
+    }
+
+    /// adds a new origin to the allowed source expressions
+    pub fn origin(mut self, origin: &'a str) -> Self {
+        self.origins.insert(origin);
+
+        self
+    }
+
+    /// adds many origins to the allowed source expressions
+    pub fn origins(mut self, origins: &[&'a str]) -> Self {
+        self.origins.extend(origins);
+
+        self
+    }
+
+    pub fn stream_bytes(&self) -> impl IntoIterator<Item = u8> {
+        self.directive
+            .as_bytes()
+            .into_iter()
+            .chain(
+                self.same_origin
+                    .then(|| b" 'self'".as_slice())
+                    .unwrap_or_default()
+                    .into_iter(),
+            )
+            .copied()
+            .chain(stream_origins(&self.origins).into_iter())
+    }
+}
+
+fn stream_origins<'a>(origins: &HashSet<&'a str>) -> Vec<u8> {
+    let mut v = Vec::new();
+    let mut last = origins.len() - 1;
+    let mut iter = origins.into_iter();
+    while let Some(o) = iter.next()
+        && last > 0
+    {
+        if last == 0 {
+            break;
+        }
+        v.extend(o.as_bytes());
+        v.push(32);
+        last -= 1;
+    }
+    let Some(o) = iter.next() else {
+        unreachable!("there is still 1 origin remaining")
+    };
+    v.extend(o.as_bytes());
+
+    v
+}

--- a/crates/pheasant_services/src/lib.rs
+++ b/crates/pheasant_services/src/lib.rs
@@ -5,6 +5,7 @@ use pheasant_prologue::{
 
 pub mod client_socket;
 pub mod content_meta;
+pub mod content_security_policy;
 pub mod cookies;
 pub mod cors;
 pub mod errors;
@@ -15,6 +16,7 @@ pub mod range;
 pub mod server_socket;
 
 pub use content_meta::MessageBodyInfo;
+// pub use content_security_policy::CSP;
 pub use cookies::{ReadCookies, WriteCookies};
 pub use cors::Cors;
 pub use errors::http_error;


### PR DESCRIPTION
### TODO
* add support for the csp fetch directives: default, img, script and style 
* add support for the csp source expressions: self and origin (e.g., example.com)

### NOTE
* this is a barebones implementation of the csp header technology, it can be used but is not very convenient and has some flexibility limitations.
* flexibility should be provided by subsequent prs that allow more detailed control over fetch directives and source expressions.
* convenience should be provided by subsequent prs that expose direct apis that turn on csp functionalities, such as, blocking xss, clickjacking, etc., 

